### PR TITLE
Include Makefile from ../extension/* and ../extension/*/extension/*

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -459,6 +459,7 @@ $(FILE_OPTIM): $(TOOLS_DIR) $(FILE_OPTIM_SRC)
 
 -include $(wildcard web/*/Makefile)
 -include $(wildcard web/extensions/*/Makefile)
+-include $(wildcard ../extensions/*/Makefile)
 -include web/Makefile
 
 # NB: $(FILE_OPTIM) *MUST* be here so "make install" builds EDATA_EMBED properly when NFS_READ_ONLY == yes
@@ -557,6 +558,7 @@ c_ext_clang_conv_debug:
 # extension init generator and extension-specific makefiles
 -include extensions/Makefile
 -include $(wildcard extensions/*/Makefile)
+-include $(wildcard ../extensions/*/extensions/*/Makefile)
 
 comma := ,
 empty :=


### PR DESCRIPTION
Hi John,
I'm currently developing an extension (called "shack_control") for the KiwiSDR that allows control of a preselector (Heros Preselector Cat) and other useful receiver addons (attenuators, preamps, switches, ...). 

I'd like to publish the source code of the first prototype to GitHub soon. In case you're interested the extension is already available on the following sites:
http://marzusch.dyndns.org:8073/?ext=shack_control&keys=s
http://kiwijo53cn.ddnss.org:8073/?ext=shack_control&keys=s

Switching is still a bit slow, because the first version is still based on shell scripts (much like "ant_switch", that I used as a template and that is still used to switch antennas), but I plan to change this to a direct MQTT connection using e. g. the Mosquitto broker soon.

To do this need to make use of addional settings (link to additional libraries) inside the extension's Makefile, but currently the main Makefile of Beagle_SDR_GPS only includes Makefiles from the "web/extensions" and "extensions" subfolder, but not from the corresponding folders outside of the project (i. e. from "../extension").

I therefore changed the Makefile in fork (branch "dl3led") to include these directories as well.
Would you mind including these changes (just 2 additional lines in the Makefile) in your distribution?
I hope I got this pull request right, didn't use GitHub so often yet. ;-)

vy 73 Ralph
dl3led@marzusch.com